### PR TITLE
Escape tab 5 right curly brace

### DIFF
--- a/snippets/form.cson
+++ b/snippets/form.cson
@@ -7,7 +7,7 @@
             ${0:boottext}
 
             <div class="btn-group pull-right">
-                ${5:{!! Form::reset("Reset", [\'class\' => \'btn btn-warning\']) !!}
+                ${5:{!! Form::reset("Reset", [\'class\' => \'btn btn-warning\']) !!\\}}
                 {!! Form::submit("${6:Add}", [\'class\' => \'btn btn-${7:success}\']) !!}
             </div>
         {!! Form::close() !!}


### PR DESCRIPTION
The far right curly brace was not being included in the tab.
Added another curly brace and then escaped using the double slash method.
